### PR TITLE
Back the reporter with a GenServer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 telemetry_metrics_appsignal-*.tar
 
-# Ignore language server specific files
-.elixir_ls
-

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 telemetry_metrics_appsignal-*.tar
 
+# Ignore language server specific files
+.elixir_ls
+

--- a/README.md
+++ b/README.md
@@ -17,23 +17,4 @@ def deps do
 end
 ```
 
-## Usage
-
-Once you've configured [the AppSignal library](https://hexdocs.pm/appsignal), you can define the metrics you want to collect:
-
-```elixir
-defp metrics do
-  [
-    counter("web.request.count"),
-    last_value("worker.queue.length"),
-    sum("worker.events.consumed"),
-    summary("db.query.duration")
-  ]
-end
-```
-
-Then attach them to the AppSignal reporter, probably in your `application.ex` file:
-
-```elixir
-TelemetryMetricsAppsignal.attach(metrics())
-```
+See the documentation on [Hexdocs](https://hexdocs.pm/telemetry_metrics_appsignal/TelemetryMetricsAppsignal.html) for more information.

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -9,11 +9,11 @@ defmodule TelemetryMetricsAppsignal do
   To use the reporter, first define a list of metrics as show here:
 
       def metrics, do:
-      [
-        summary("phoenix.endpoint.stop.duration"),
-        last_value("vm.memory.total"),
-        counter("my_app.my_server.call.exception")
-      ]
+        [
+          summary("phoenix.endpoint.stop.duration"),
+          last_value("vm.memory.total"),
+          counter("my_app.my_server.call.exception")
+        ]
 
   It's recommended to start TelemetryMetricsAppsignal under a supervision tree,
   either in your main application or as recommended [here](https://hexdocs.pm/phoenix/telemetry.html#the-telemetry-supervisor)

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -72,7 +72,7 @@ defmodule TelemetryMetricsAppsignal do
           | Sum.t()
           | Summary.t()
 
-  @type option :: {:metric, [metric]} | {:name, GenServer.name()}
+  @type option :: {:metrics, [metric]} | {:name, GenServer.name()}
 
   @spec start_link([option]) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(opts) do

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -1,4 +1,60 @@
 defmodule TelemetryMetricsAppsignal do
+  @moduledoc """
+  AppSignal Reporter for [`Telemetry.Metrics`](https://github.com/beam-telemetry/telemetry_metrics) definitions.
+
+  This reporter is useful for getting [custom metrics](https://docs.appsignal.com/metrics/custom.html)
+  into AppSignal from your application. These custom metrics are especially
+  useful for building custom dashboards.
+
+  To use the reporter, first define a list of metrics as show here:
+
+      def metrics, do:
+      [
+        summary("phoenix.endpoint.stop.duration"),
+        last_value("vm.memory.total"),
+        counter("my_app.my_server.call.exception")
+      ]
+
+  It's recommended to start TelemetryMetricsAppsignal under a supervision tree,
+  either in your main application or as recommended [here](https://hexdocs.pm/phoenix/telemetry.html#the-telemetry-supervisor)
+  if using Phoenix:
+
+      {TelemetryMetricsAppsignal, [metrics: metrics()]}
+
+  Putting that altogether, your configuration could look something like this:
+
+      def start_link(_arg) do
+        children = [
+          {TelemetryMetricsAppsignal, [metrics: metrics()]},
+          ...
+        ]
+        Supervisor.init(children, strategy: :one_for_one)
+      end
+
+      defp metrics, do:
+        [
+          summary("phoenix.endpoint.stop.duration"),
+          last_value("vm.memory.total"),
+          counter("my_app.my_server.call.exception")
+        ]
+
+    Optionally you can register a name:
+
+        {TelemetryMetricsAppsignal,
+          [metrics: metrics(), name: MyTelemetryMetricsAppsignal]}
+
+  The following table shows how `Telemetry.Metrics` metrics map to [AppSignal
+  metrics](https://docs.appsignal.com/metrics/custom.html#metric-types):
+
+  | Telemetry.Metrics     | AppSignal |
+  |-----------------------|-----------|
+  | `last_value`          | `guage` |
+  | `counter`             | `counter` |
+  | `sum`                 | `counter`, increased by the provided value |
+  | `summary`             | `measurement` |
+  | `distribution`        | Not supported |
+  """
+  use GenServer
   require Logger
 
   alias Telemetry.Metrics.Counter
@@ -8,7 +64,6 @@ defmodule TelemetryMetricsAppsignal do
   alias Telemetry.Metrics.Summary
 
   @appsignal Application.compile_env(:telemetry_metrics_appsignal, :appsignal, Appsignal)
-  @handler_prefix "telemetry_metrics_appsignal"
 
   @type metric ::
           Counter.t()
@@ -17,33 +72,40 @@ defmodule TelemetryMetricsAppsignal do
           | Sum.t()
           | Summary.t()
 
-  @type option :: {:namespace, String.t()}
+  @type option :: {:metric, [metric]} | {:name, GenServer.name()}
 
-  @spec attach([metric], keyword(option)) :: no_return()
-  def attach(metrics, opts \\ []) do
-    namespace = Keyword.get(opts, :namespace)
-    handler_prefix = prepare_handler_prefix(namespace)
+  @spec start_link([option]) :: :ignore | {:error, any} | {:ok, pid}
+  def start_link(opts) do
+    server_opts = Keyword.take(opts, [:name])
 
-    metrics
-    |> Enum.group_by(& &1.event_name)
-    |> Enum.each(fn {event_name, metrics} ->
-      handler_id = Enum.join(handler_prefix ++ event_name, "_")
+    metrics =
+      opts[:metrics] ||
+        raise ArgumentError, "the :metrics option is required by #{inspect(__MODULE__)}"
 
-      :telemetry.attach(handler_id, event_name, &handle_event/4, metrics: metrics)
-    end)
+    GenServer.start_link(__MODULE__, metrics, server_opts)
   end
 
-  @spec detach([metric], keyword(option)) :: no_return()
-  def detach(metrics, opts \\ []) do
-    namespace = Keyword.get(opts, :namespace)
-    handler_prefix = prepare_handler_prefix(namespace)
+  @impl true
+  @spec init([metric]) :: {:ok, [any]}
+  def init(metrics) do
+    Process.flag(:trap_exit, true)
+    groups = Enum.group_by(metrics, & &1.event_name)
 
-    metrics
-    |> Enum.map(& &1.event_name)
-    |> Enum.each(fn event_name ->
-      handler_id = Enum.join(handler_prefix ++ event_name, "_")
-      :telemetry.detach(handler_id)
-    end)
+    for {event, metrics} <- groups do
+      id = {__MODULE__, event, self()}
+      :telemetry.attach(id, event, &handle_event/4, metrics: metrics)
+    end
+
+    {:ok, Map.keys(groups)}
+  end
+
+  @impl true
+  def terminate(_, events) do
+    for event <- events do
+      :telemetry.detach({__MODULE__, event, self()})
+    end
+
+    :ok
   end
 
   defp handle_event(_event_name, measurements, metadata, config) do
@@ -54,10 +116,6 @@ defmodule TelemetryMetricsAppsignal do
       tags = prepare_metric_tags(metric, metadata)
       send_metric(metric, value, tags)
     end)
-  end
-
-  defp prepare_handler_prefix(namespace) do
-    [@handler_prefix, namespace] |> Enum.reject(&is_nil/1)
   end
 
   defp prepare_metric_value(measurement, measurements)

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -74,7 +74,7 @@ defmodule TelemetryMetricsAppsignal do
 
   @type option :: {:metrics, [metric]} | {:name, GenServer.name()}
 
-  @spec start_link([option]) :: :ignore | {:error, any} | {:ok, pid}
+  @spec start_link([option]) :: GenServer.on_start()
   def start_link(opts) do
     server_opts = Keyword.take(opts, [:name])
     metrics = Keyword.get(opts, :metrics, [])

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -82,7 +82,7 @@ defmodule TelemetryMetricsAppsignal do
   end
 
   @impl true
-  @spec init([metric]) :: {:ok, [any]}
+  @spec init([metric]) :: {:ok, [[atom]]}
   def init(metrics) do
     Process.flag(:trap_exit, true)
     groups = Enum.group_by(metrics, & &1.event_name)

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -6,7 +6,7 @@ defmodule TelemetryMetricsAppsignal do
   into AppSignal from your application. These custom metrics are especially
   useful for building custom dashboards.
 
-  To use the reporter, first define a list of metrics as show here:
+  To use the reporter, first define a list of metrics as shown here:
 
       def metrics, do:
         [

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -77,11 +77,7 @@ defmodule TelemetryMetricsAppsignal do
   @spec start_link([option]) :: :ignore | {:error, any} | {:ok, pid}
   def start_link(opts) do
     server_opts = Keyword.take(opts, [:name])
-
-    metrics =
-      opts[:metrics] ||
-        raise ArgumentError, "the :metrics option is required by #{inspect(__MODULE__)}"
-
+    metrics = Keyword.get(opts, :metrics, [])
     GenServer.start_link(__MODULE__, metrics, server_opts)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule TelemetryMetricsAppsignal.MixProject do
   defp docs do
     [
       extras: ["CHANGELOG.md", "README.md"],
-      main: "readme"
+      main: "TelemetryMetricsAppsignal"
     ]
   end
 end

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -10,10 +10,20 @@ defmodule TelemetryMetricsAppsignalTest do
   alias Telemetry.Metrics.Sum
   alias Telemetry.Metrics.Summary
 
-  @handler_prefix "telemetry_metrics_appsignal"
   @moduletag capture_log: true
 
   setup :verify_on_exit!
+
+  test "registering a name with the genserver" do
+    pid = start_reporter(metrics: [], name: __MODULE__)
+    assert Process.whereis(__MODULE__) == pid
+  end
+
+  test "not providing metrics in the opts raises" do
+    assert_raise RuntimeError, fn ->
+      start_reporter([])
+    end
+  end
 
   test "attaching and detaching telemetry handlers" do
     metrics = [
@@ -24,7 +34,7 @@ defmodule TelemetryMetricsAppsignalTest do
       summary("db.query.duration")
     ]
 
-    TelemetryMetricsAppsignal.attach(metrics)
+    reporter = start_reporter(metrics: metrics)
 
     attached_handlers = :telemetry.list_handlers([])
 
@@ -35,39 +45,19 @@ defmodule TelemetryMetricsAppsignalTest do
       [:db, :query] => [Summary]
     }
 
-    Enum.each(event_metrics, fn {event_name, expected_metrics} ->
-      handler_id = [@handler_prefix | event_name] |> Enum.join("_")
-      handler = Enum.find(attached_handlers, &(&1.id == handler_id))
-      handler_metrics = handler.config[:metrics]
+    actual_event_metrics =
+      Enum.reduce(attached_handlers, %{}, fn handler, metrics_acc ->
+        handler_metrics = handler.config[:metrics]
+        event_name = List.first(handler.config[:metrics]).event_name
+        modules = Enum.map(handler_metrics, & &1.__struct__())
+        Map.put(metrics_acc, event_name, modules)
+      end)
 
-      assert handler.event_name == event_name
-      assert Enum.map(handler_metrics, & &1.__struct__()) == expected_metrics
-    end)
+    assert Enum.sort(actual_event_metrics) == Enum.sort(event_metrics)
 
-    TelemetryMetricsAppsignal.detach(metrics)
-    attached_handlers = :telemetry.list_handlers([])
-    assert attached_handlers == []
-  end
-
-  test "allwing to configure handler namespace" do
-    metric = counter("web.request.count")
-    TelemetryMetricsAppsignal.attach([metric], namespace: "api")
-    TelemetryMetricsAppsignal.attach([metric], namespace: "rpc")
+    Agent.stop(reporter)
     attached_handlers = :telemetry.list_handlers([])
 
-    handler_ids =
-      attached_handlers
-      |> Enum.map(& &1.id)
-      |> Enum.sort()
-
-    assert handler_ids == [
-             "telemetry_metrics_appsignal_api_web_request",
-             "telemetry_metrics_appsignal_rpc_web_request"
-           ]
-
-    TelemetryMetricsAppsignal.detach([metric], namespace: "api")
-    TelemetryMetricsAppsignal.detach([metric], namespace: "rpc")
-    attached_handlers = :telemetry.list_handlers([])
     assert attached_handlers == []
   end
 
@@ -81,7 +71,7 @@ defmodule TelemetryMetricsAppsignalTest do
       sum("worker.events.consumed")
     ]
 
-    TelemetryMetricsAppsignal.attach(metrics)
+    start_reporter(metrics: metrics)
 
     ref = make_ref()
 
@@ -115,14 +105,12 @@ defmodule TelemetryMetricsAppsignalTest do
 
     :telemetry.execute([:worker, :events], %{consumed: 11}, %{})
     assert_receive {^ref, :called}
-
-    TelemetryMetricsAppsignal.detach(metrics)
   end
 
   test "reporting gauge metrics" do
     # `Telemetry.Metrics.LastValue` maps to AppSignal's gauge metric
     metric = last_value("worker.queue.length")
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
 
     parent = self()
     ref = make_ref()
@@ -135,14 +123,12 @@ defmodule TelemetryMetricsAppsignalTest do
 
     :telemetry.execute([:worker, :queue], %{length: 42}, %{})
     assert_receive {^ref, :called}
-
-    TelemetryMetricsAppsignal.detach([metric])
   end
 
   test "reporting measurement metrics" do
     # `Telemetry.Metrics.Summary` maps to AppSignal's measurement metric
     metric = summary("db.query.duration")
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
 
     parent = self()
     ref = make_ref()
@@ -155,13 +141,11 @@ defmodule TelemetryMetricsAppsignalTest do
 
     :telemetry.execute([:db, :query], %{duration: 99}, %{})
     assert_receive {^ref, :called}
-
-    TelemetryMetricsAppsignal.detach([metric])
   end
 
   test "converting time units" do
     metric = summary("db.query.duration", unit: {:native, :millisecond})
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
 
     native_time = System.convert_time_unit(123, :millisecond, :native)
     parent = self()
@@ -175,13 +159,11 @@ defmodule TelemetryMetricsAppsignalTest do
 
     :telemetry.execute([:db, :query], %{duration: native_time}, %{})
     assert_receive {^ref, :called}
-
-    TelemetryMetricsAppsignal.detach([metric])
   end
 
   test "specifying metric tags" do
     metric = last_value("worker.queue.length", tags: [:queue, :host, :region])
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
 
     parent = self()
     ref = make_ref()
@@ -205,8 +187,6 @@ defmodule TelemetryMetricsAppsignalTest do
     ]
 
     for tags <- tag_permutations, do: assert_receive({^ref, ^tags})
-
-    TelemetryMetricsAppsignal.detach([metric])
   end
 
   test "specifying metric tag values" do
@@ -231,16 +211,18 @@ defmodule TelemetryMetricsAppsignalTest do
 
   test "handling unsupported metrics" do
     metric = distribution("web.request.duration", buckets: [100, 200, 400])
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
     :telemetry.execute([:web, :request], %{duration: 99}, %{})
-    TelemetryMetricsAppsignal.detach([metric])
   end
 
   test "handling missing measurement" do
     metric = summary("db.query.duration")
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
     :telemetry.execute([:db, :query], %{}, %{})
-    TelemetryMetricsAppsignal.detach([metric])
+  end
+
+  defp start_reporter(opts) do
+    start_supervised!({TelemetryMetricsAppsignal, opts})
   end
 
   defp get_and_put_value(metadata) do

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -19,7 +19,7 @@ defmodule TelemetryMetricsAppsignalTest do
     assert Process.whereis(__MODULE__) == pid
   end
 
-  test "not providing metrics in the opts raises" do
+  test "not providing metrics" do
     start_reporter([])
     attached_handlers = :telemetry.list_handlers([])
     actual_event_metrics = fetch_event_metrics(attached_handlers)

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -192,7 +192,7 @@ defmodule TelemetryMetricsAppsignalTest do
 
   test "specifying metric tag values" do
     metric = last_value("worker.queue.length", tags: [:value], tag_values: &get_and_put_value/1)
-    TelemetryMetricsAppsignal.attach([metric])
+    start_reporter(metrics: [metric])
 
     parent = self()
     ref = make_ref()
@@ -206,8 +206,6 @@ defmodule TelemetryMetricsAppsignalTest do
     :telemetry.execute([:worker, :queue], %{length: 42}, %{})
 
     assert_receive({^ref, %{value: "value"}})
-
-    TelemetryMetricsAppsignal.detach([metric])
   end
 
   test "handling unsupported metrics" do


### PR DESCRIPTION
I mostly used other reporter libraries as examples in combination with the `telemetry_metrics` docs to make these changes.

Changes include:

- adding a genserver to `TelemetryMetricsAppsignal`
- adding documentation to `TelemetryMetricsAppsignal`
- changing handler IDs to be unique using the method outlined in the [docs](https://hexdocs.pm/telemetry_metrics/writing_reporters.html#attaching-event-handlers) rather than using the namespace method that existed previously. Is this okay or do you still need name spacing in some way for the handlers?

see https://github.com/surgeventures/telemetry_metrics_appsignal/issues/2