### PR TITLE
Fix tag values not populating

### DIFF
--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -51,7 +51,7 @@ defmodule TelemetryMetricsAppsignal do
 
     Enum.each(metrics, fn metric ->
       value = prepare_metric_value(metric.measurement, measurements)
-      tags = prepare_metric_tags(metric.tags, metadata)
+      tags = prepare_metric_tags(metric, metadata)
       send_metric(metric, value, tags)
     end)
   end
@@ -73,8 +73,9 @@ defmodule TelemetryMetricsAppsignal do
 
   defp prepare_metric_value(_, _), do: nil
 
-  defp prepare_metric_tags(tags, metadata) do
-    Map.take(metadata, tags)
+  defp prepare_metric_tags(metric, metadata) do
+    tag_values = metric.tag_values.(metadata)
+    Map.take(tag_values, metric.tags)
   end
 
   defp send_metric(%Counter{} = metric, _value, tags) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TelemetryMetricsAppsignal.MixProject do
   def project do
     [
       app: :telemetry_metrics_appsignal,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       source_url: "https://github.com/surgeventures/telemetry_metrics_appsignal",


### PR DESCRIPTION
The `telemetry_metrics` [docs](https://hexdocs.pm/telemetry_metrics/writing_reporters.html#reacting-to-events) have great resources on how to extract tags. This change implements their recommendations.

see #4 