### PR TITLE
Fix Telemetry 1.x warning caused by local function capture

### DIFF
--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -89,7 +89,7 @@ defmodule TelemetryMetricsAppsignal do
 
     for {event, metrics} <- groups do
       id = {__MODULE__, event, self()}
-      :telemetry.attach(id, event, &handle_event/4, metrics: metrics)
+      :telemetry.attach(id, event, &__MODULE__.handle_event/4, metrics: metrics)
     end
 
     {:ok, Map.keys(groups)}
@@ -104,7 +104,7 @@ defmodule TelemetryMetricsAppsignal do
     :ok
   end
 
-  defp handle_event(_event_name, measurements, metadata, config) do
+  def handle_event(_event_name, measurements, metadata, config) do
     metrics = Keyword.get(config, :metrics, [])
 
     Enum.each(metrics, fn metric ->


### PR DESCRIPTION
This PR fixes the warning from `telemetry` below.

```
Function passed as a handler with ID {TelemetryMetricsAppsignal, [:worker], #PID<0.1478.0>} is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach-4
```