### PR TITLE
Allow binary functions when calculating measurments

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule TelemetryMetricsAppsignal.MixProject do
       {:hammox, "~> 0.2", only: :test},
       {:jason, "~> 1.1", optional: true},
       {:telemetry, "~> 0.4 or ~> 1.0"},
-      {:telemetry_metrics, "~> 0.6"}
+      {:telemetry_metrics, "~> 0.4"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule TelemetryMetricsAppsignal.MixProject do
       {:hammox, "~> 0.2", only: :test},
       {:jason, "~> 1.1", optional: true},
       {:telemetry, "~> 0.4 or ~> 1.0"},
-      {:telemetry_metrics, "~> 0.4"}
+      {:telemetry_metrics, "~> 0.6"}
     ]
   end
 

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -145,6 +145,54 @@ defmodule TelemetryMetricsAppsignalTest do
     assert_receive {^ref, :called}
   end
 
+  test "reporting calculated metrics with unary functions" do
+    # `Telemetry.Metrics.Summary` maps to AppSignal's measurement metric
+    metric =
+      summary("db.query.foo",
+        measurement: fn measurement ->
+          measurement.duration * 10
+        end
+      )
+
+    start_reporter(metrics: [metric])
+
+    parent = self()
+    ref = make_ref()
+
+    expect(AppsignalMock, :add_distribution_value, fn
+      "db.query.foo", 990, %{} ->
+        send(parent, {ref, :called})
+        :ok
+    end)
+
+    :telemetry.execute([:db, :query], %{duration: 99}, %{})
+    assert_receive {^ref, :called}
+  end
+
+  test "reporting calculated metrics with binary functions" do
+    # `Telemetry.Metrics.Summary` maps to AppSignal's measurement metric
+    metric =
+      summary("db.query.foo",
+        measurement: fn _measurement, metadata ->
+          metadata.some_metadata_value + 1
+        end
+      )
+
+    start_reporter(metrics: [metric])
+
+    parent = self()
+    ref = make_ref()
+
+    expect(AppsignalMock, :add_distribution_value, fn
+      "db.query.foo", 2, %{} ->
+        send(parent, {ref, :called})
+        :ok
+    end)
+
+    :telemetry.execute([:db, :query], %{duration: 99}, %{some_metadata_value: 1})
+    assert_receive {^ref, :called}
+  end
+
   test "converting time units" do
     metric = summary("db.query.duration", unit: {:native, :millisecond})
     start_reporter(metrics: [metric])

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -160,7 +160,7 @@ defmodule TelemetryMetricsAppsignalTest do
     ref = make_ref()
 
     expect(AppsignalMock, :add_distribution_value, fn
-      "db.query.foo", 990, %{} ->
+      "db.query.duration_multiplied", 990, %{} ->
         send(parent, {ref, :called})
         :ok
     end)

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -148,7 +148,7 @@ defmodule TelemetryMetricsAppsignalTest do
   test "reporting calculated metrics with unary functions" do
     # `Telemetry.Metrics.Summary` maps to AppSignal's measurement metric
     metric =
-      summary("db.query.foo",
+      summary("db.query.duration_multiplied",
         measurement: fn measurements ->
           measurements.duration * 10
         end

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -172,9 +172,9 @@ defmodule TelemetryMetricsAppsignalTest do
   test "reporting calculated metrics with binary functions" do
     # `Telemetry.Metrics.Summary` maps to AppSignal's measurement metric
     metric =
-      summary("db.query.foo",
-        measurement: fn _measurement, metadata ->
-          metadata.some_metadata_value + 1
+      summary("db.query.duration_multiplied",
+        measurement: fn measurements, metadata ->
+          measurements.duration * metadata.multiplier
         end
       )
 
@@ -184,12 +184,12 @@ defmodule TelemetryMetricsAppsignalTest do
     ref = make_ref()
 
     expect(AppsignalMock, :add_distribution_value, fn
-      "db.query.foo", 2, %{} ->
+      "db.query.duration_multiplied", 198, %{} ->
         send(parent, {ref, :called})
         :ok
     end)
 
-    :telemetry.execute([:db, :query], %{duration: 99}, %{some_metadata_value: 1})
+    :telemetry.execute([:db, :query], %{duration: 99}, %{multiplier: 2})
     assert_receive {^ref, :called}
   end
 


### PR DESCRIPTION
Since v0.60, Telemetry.Metrics [supports computed measurements using a binary function](https://hexdocs.pm/telemetry_metrics/0.6.0/Telemetry.Metrics.html). These functions are given the source event measurements as well as the event metadata. 

Applications don't provide everything we might want to measure in their events so being able to compute our own values is handy. I've written an update to the `prepare_metric_value` function that adds support for binary `measurement` functions.

To add support for the feature, this PR includes an update to the `telemetry_metrics` dependency as well.