### PR TITLE
Fix Elixir warnings

### DIFF
--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -185,7 +185,7 @@ defmodule TelemetryMetricsAppsignal do
   end
 
   defp send_metric(metric, _measurements, _tags) do
-    Logger.warn("Ignoring unsupported metric #{inspect(metric)}")
+    Logger.warning("Ignoring unsupported metric #{inspect(metric)}")
   end
 
   defp call_appsignal(function_name, key, value, tags) when is_list(key) do
@@ -202,7 +202,7 @@ defmodule TelemetryMetricsAppsignal do
   end
 
   defp call_appsignal(function_name, key, value, tags) do
-    Logger.warn("""
+    Logger.warning("""
     Attempted to send metrics invalid with AppSignal library: \
     #{inspect(function_name)}(\
     #{inspect(key)}, \

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -379,7 +379,7 @@ defmodule TelemetryMetricsAppsignalTest do
     Enum.reduce(attached_handlers, %{}, fn handler, metrics_acc ->
       handler_metrics = handler.config[:metrics]
       event_name = List.first(handler.config[:metrics]).event_name
-      modules = Enum.map(handler_metrics, & &1.__struct__())
+      modules = Enum.map(handler_metrics, & &1.__struct__)
       Map.put(metrics_acc, event_name, modules)
     end)
   end


### PR DESCRIPTION
The changes mop up some compilation warnings.

This is a compilation warning:

```elixir
Compiling 1 file (.ex)
     warning: Logger.warn/1 is deprecated. Use Logger.warning/2 instead
     │
 188 │     Logger.warn("Ignoring unsupported metric #{inspect(metric)}")
     │            ~
     │
     └─ lib/telemetry_metrics_appsignal.ex:188:12: TelemetryMetricsAppsignal.send_metric/3
```

While this one is a runtime warning during tests:

```elixir
warning: using module.function() notation (with parentheses) to fetch map field :__struct__ is deprecated, you must remove the parentheses: map.field

  (elixir 1.18.4) lib/enum.ex:1714: Enum."-map/2-lists^map/1-1-"/2
  test/telemetry_metrics_appsignal_test.exs:382: anonymous fn/2 in TelemetryMetricsAppsignalTest.fetch_event_metrics/1
  (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
  test/telemetry_metrics_appsignal_test.exs:55: TelemetryMetricsAppsignalTest."test attaching and detaching telemetry handlers"/1
  (ex_unit 1.18.4) lib/ex_unit/runner.ex:511: ExUnit.Runner.exec_test/2
  (stdlib 6.2.2) timer.erl:595: :timer.tc/2
  (ex_unit 1.18.4) lib/ex_unit/runner.ex:433: anonymous fn/6 in ExUnit.Runner.spawn_test_monitor/4
```