### PR TITLE
Resolve measurements for counter metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Counter metrics now resolve measurements like other metric types, defaulting to 1 if measurement is not present.
+
 ## [1.5.0] - 2024-06-19
 
 ### Added

--- a/lib/telemetry_metrics_appsignal.ex
+++ b/lib/telemetry_metrics_appsignal.ex
@@ -129,8 +129,6 @@ defmodule TelemetryMetricsAppsignal do
 
   defp prepare_metric_value(metric, measurements, metadata)
 
-  defp prepare_metric_value(%Counter{}, _measurements, _metadata), do: 1
-
   defp prepare_metric_value(%{measurement: convert}, measurements, metadata)
        when is_function(convert, 2) do
     convert.(measurements, metadata)
@@ -146,15 +144,13 @@ defmodule TelemetryMetricsAppsignal do
     measurements[measurement]
   end
 
+  defp prepare_metric_value(%Counter{}, _measurements, _metadata), do: 1
+
   defp prepare_metric_value(_, _, _), do: nil
 
   defp prepare_metric_tags(metric, metadata) do
     tag_values = metric.tag_values.(metadata)
     Map.take(tag_values, metric.tags)
-  end
-
-  defp send_metric(%Counter{} = metric, _value, tags) do
-    call_appsignal(:increment_counter, metric.name, 1, tags)
   end
 
   defp send_metric(%Summary{} = metric, value, tags) do
@@ -175,7 +171,7 @@ defmodule TelemetryMetricsAppsignal do
     )
   end
 
-  defp send_metric(%Sum{} = metric, value, tags) do
+  defp send_metric(metric, value, tags) when is_struct(metric, Counter) or is_struct(metric, Sum) do
     call_appsignal(
       :increment_counter,
       metric.name,

--- a/test/telemetry_metrics_appsignal_test.exs
+++ b/test/telemetry_metrics_appsignal_test.exs
@@ -75,19 +75,18 @@ defmodule TelemetryMetricsAppsignalTest do
 
     ref = make_ref()
 
-    expect(AppsignalMock, :increment_counter, fn
-      "web.request.count", 1, %{} ->
+    expect(AppsignalMock, :increment_counter, fn "web.request.count", 2, %{} ->
         send(parent, {ref, :called})
         :ok
     end)
 
     assert capture_log(fn ->
-             :telemetry.execute([:web, :request], %{}, %{})
+             :telemetry.execute([:web, :request], %{count: 2}, %{})
            end) == ""
 
     assert_receive {^ref, :called}
 
-    # Measurements should be ignored for counter metric
+    # Default to increments of one if measurement not present
     ref = make_ref()
 
     expect(AppsignalMock, :increment_counter, fn "web.request.count", 1, _tags ->
@@ -96,7 +95,7 @@ defmodule TelemetryMetricsAppsignalTest do
     end)
 
     assert capture_log(fn ->
-             :telemetry.execute([:web, :request], %{count: 5}, %{})
+             :telemetry.execute([:web, :request], %{}, %{})
            end) == ""
 
     assert_receive {^ref, :called}


### PR DESCRIPTION
This patch changes the resolution behaviour for `Counter` metrics to fallback to 1 only if the given measurement is not a function and not a key in the event measurements.