### PR TITLE
[team-devex#546] Swap actions/cache for step-security/runs-on-cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Cache dependencies
         with:
           path: |
@@ -61,7 +61,7 @@ jobs:
             deps-${{ hashFiles('mix.lock') }}
             deps-
       - run: mix deps.get
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Cache build
         with:
           path: |
@@ -95,7 +95,7 @@ jobs:
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Cache dependencies
         with:
           path: |
@@ -105,7 +105,7 @@ jobs:
             deps-${{ hashFiles('mix.lock') }}
             deps-
       - run: mix deps.get
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Cache build
         with:
           path: |
@@ -114,7 +114,7 @@ jobs:
           restore-keys: |
             build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
             build-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         name: Restore PLT cache
         id: plt_cache
         with:


### PR DESCRIPTION
Swaps `actions/cache` (and its `/restore`, `/save` variants where present) for `step-security/runs-on-cache`, the org-canonical caching action (already 209 use sites across 50+ repos, all on this exact pin, v5.0.7).

Why this is safe:
- **Drop-in replacement** for `actions/cache@v5` — all official options supported, `with:` blocks are untouched by this PR.
- **Transparent fallback**: on runs-on runners it uses the dedicated S3 cache bucket (faster, no size limit); on GitHub-hosted runners with no bucket it transparently behaves like `actions/cache`. Per upstream: "you can switch between RunsOn runners and official GitHub runners with no change."
- On runs-on runners this also stops paying GitHub-cache egress.

Part of the A25.2 consolidation pass: https://github.com/freshaengineering/team-devex/issues/546 (parent: https://github.com/freshaengineering/team-devex/issues/505). Full evidence: https://github.com/freshaengineering/team-devex/issues/504#issuecomment-5168144698

🤖 Generated with [Claude Code](https://claude.com/claude-code)